### PR TITLE
Refactor SimulationParameters to inherit from nn.Module

### DIFF
--- a/svetlanna/elements/diffractive_layer.py
+++ b/svetlanna/elements/diffractive_layer.py
@@ -38,6 +38,11 @@ class DiffractiveLayer(Element):
         self.mask = self.process_parameter("mask", mask)
         self.mask_norm = self.process_parameter("mask_norm", mask_norm)
 
+        # Precompute cast operations so that forward() uses only
+        # tensor ops (no Python dict/cache lookups → torch.compile-safe)
+        self._cast_idx, self._cast_swaps = \
+            self.simulation_parameters.precompute_cast("y", "x")
+
     @property
     def transmission_function(self) -> torch.Tensor:
         r"""
@@ -45,9 +50,11 @@ class DiffractiveLayer(Element):
         $\exp\left(2\pi i \dfrac{\text{mask}}{\text{mask\_norm}}\right)$.
         The shape of the tensor is broadcastable to the incident wavefront's shape.
         """
-        return self.simulation_parameters.cast(
-            torch.exp((2j * torch.pi / self.mask_norm) * self.mask), "y", "x"
-        )
+        t = torch.exp((2j * torch.pi / self.mask_norm) * self.mask)
+        t = t[self._cast_idx]
+        for i, j in self._cast_swaps:
+            t = t.swapaxes(i, j)
+        return t
 
     def forward(self, incident_wavefront: Wavefront) -> Wavefront:
         return incident_wavefront * self.transmission_function

--- a/svetlanna/elements/element.py
+++ b/svetlanna/elements/element.py
@@ -53,20 +53,6 @@ class Element(nn.Module, metaclass=ABCMeta):
     def forward(self, incident_wavefront: Wavefront) -> Wavefront:
         """Forward propagation through the optical element."""
 
-    def to(self, *args, **kwargs) -> Self:
-        """
-        Move element to a different device/dtype.
-
-        Overrides `torch.nn.Module.to()` to also transfer simulation_parameters.
-
-        Returns
-        -------
-        Self
-            The element itself, not a copy.
-        """
-        self.simulation_parameters.to(*args, **kwargs)
-        return super().to(*args, **kwargs)
-
     def to_specs(self) -> Iterable[ParameterSpecs | SubelementSpecs]:
         for name, parameter in self.named_parameters():
 

--- a/svetlanna/simulation_parameters.py
+++ b/svetlanna/simulation_parameters.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, Self, overload
 from typing_extensions import deprecated
 import torch
+from torch import nn
 import warnings
 from collections.abc import Mapping
-from functools import lru_cache
 
 
 class AxisNotFound(Exception):
@@ -14,7 +14,18 @@ class AxisNotFound(Exception):
 
 
 REQUIRED_AXES = ("x", "y", "wavelength")
-CACHE_SIZE = 128
+
+# nn.Module attributes that would break if used as axis names
+_RESERVED_AXIS_NAMES = frozenset({
+    "training", "forward", "extra_repr",
+    "children", "modules", "named_modules",
+    "parameters", "named_parameters", "buffers", "named_buffers",
+    "state_dict", "load_state_dict",
+    "register_buffer", "register_parameter", "register_module",
+    "add_module", "apply", "zero_grad",
+    "train", "eval", "requires_grad_",
+    "to", "cpu", "cuda", "half", "float", "double", "bfloat16",
+})
 
 
 def legacy_axis_support(name: str) -> str:
@@ -31,7 +42,7 @@ def legacy_axis_support(name: str) -> str:
     return name
 
 
-class SimulationParameters:
+class SimulationParameters(nn.Module):
 
     @overload
     def __init__(
@@ -62,6 +73,17 @@ class SimulationParameters:
         Manages coordinate systems and physical parameters for optical simulations.
         Required axes: `x`, `y`, `wavelength`.
         Additional axes can be added.
+
+        Inherits from ``nn.Module`` so that axes are registered as buffers and
+        participate in automatic device management when used as submodules of
+        Elements.
+
+        .. note::
+            Axes are registered as **non-persistent** buffers (``persistent=False``).
+            This means they are **not included** in ``state_dict()`` and will not
+            be saved during checkpointing. The simulation grid must be provided
+            when constructing the model; it does not need to be restored from
+            a checkpoint.
 
         Examples
         --------
@@ -114,6 +136,8 @@ class SimulationParameters:
 
 
         """
+        super().__init__()
+
         # Handle backward compatibility
         if axes is not None:
             if kwaxes:
@@ -143,6 +167,15 @@ class SimulationParameters:
             if not isinstance(name, str):
                 raise TypeError(
                     f"Axis names must be strings, but got {type(name)}: {name})"
+                )
+            if name.startswith("_"):
+                raise ValueError(
+                    f"Axis name '{name}' cannot start with underscore "
+                    "(reserved for internal attributes)"
+                )
+            if name in _RESERVED_AXIS_NAMES:
+                raise ValueError(
+                    f"Axis name '{name}' conflicts with nn.Module attribute"
                 )
 
         # Check required axes presence
@@ -205,11 +238,23 @@ class SimulationParameters:
                 name: tensor.to(device) for name, tensor in converted_axes.items()
             }
 
-        self.__names_reversed = tuple(non_scalar_names)
-        self.__names = tuple(reversed(non_scalar_names))
-        self.__names_scalar = tuple(scalar_names)
-        self.__axes_dict = converted_axes
-        self.__device = device
+        # Register axes as non-persistent buffers
+        for name, tensor in converted_axes.items():
+            self.register_buffer(name, tensor, persistent=False)
+
+        # Track axis names in plain instance attributes
+        self._non_scalar_names_insertion_order: tuple[str, ...] = tuple(non_scalar_names)
+        self._non_scalar_names: tuple[str, ...] = tuple(reversed(non_scalar_names))
+        self._scalar_names: tuple[str, ...] = tuple(scalar_names)
+
+        # Initialize dict-based caches (replaces @lru_cache)
+        self._cache_axis_sizes: dict[tuple[str, ...] | None, torch.Size] = {}
+        self._cache_cast_info: dict[
+            tuple[str, ...], tuple[tuple[str, ...], tuple[int, ...]]
+        ] = {}
+
+        # Enable read-only protection — MUST be last
+        self._all_axis_names: frozenset[str] = frozenset(converted_axes.keys())
 
         if TYPE_CHECKING:
             self.x: torch.Tensor
@@ -219,12 +264,13 @@ class SimulationParameters:
             self.wavelength: torch.Tensor
 
     def _clear_caches(self) -> None:
-        """Clear all cached method results when axes change."""
-        # Clear LRU caches
-        if hasattr(self.axis_sizes, "cache_clear"):
-            self.axis_sizes.cache_clear()
-        if hasattr(self._cast_info, "cache_clear"):
-            self._cast_info.cache_clear()
+        """Clear all cached method results.
+
+        Since axes are immutable after ``__init__``, caches never go stale
+        during normal use. This method exists only for testing.
+        """
+        self._cache_axis_sizes.clear()
+        self._cache_cast_info.clear()
 
     ###########################################################################
     # Initializers
@@ -299,7 +345,10 @@ class SimulationParameters:
         SimulationParameters
             A new instance with cloned axes.
         """
-        cloned_axes = {name: value.clone() for name, value in self.__axes_dict.items()}
+        # _buffers is an OrderedDict — preserves axis insertion order
+        cloned_axes = {
+            name: buf.clone() for name, buf in self._buffers.items() if buf is not None
+        }
         return SimulationParameters(cloned_axes)
 
     ###########################################################################
@@ -323,11 +372,15 @@ class SimulationParameters:
             `True` if all axes are equal, `False` otherwise.
         """
 
-        if set(self.__axes_dict.keys()) != set(value.__axes_dict.keys()):
+        if self._all_axis_names != value._all_axis_names:
             return False
 
-        for name in self.__axes_dict.keys():
-            if not torch.equal(self.__axes_dict[name], value.__axes_dict[name]):
+        # Axis ordering matters — different order means incompatible tensor layouts
+        if self._non_scalar_names != value._non_scalar_names:
+            return False
+
+        for name in self._all_axis_names:
+            if not torch.equal(getattr(self, name), getattr(value, name)):
                 return False
 
         return True
@@ -339,49 +392,43 @@ class SimulationParameters:
     @property
     def axis_names(self) -> tuple[str, ...]:
         """Get names of non-scalar axes (those with length > 1)."""
-        return self.__names
+        return self._non_scalar_names
 
     @property
     def _axis_names_scalar(self) -> tuple[str, ...]:
         """Get names of scalar (0-dimensional) axes."""
-        return self.__names_scalar
+        return self._scalar_names
 
-    def __getattribute__(self, name: str) -> Any:
-        """Get axis value by name using attribute syntax."""
-        # Avoid infinite recursion for private attributes
-        if name == "_SimulationParameters__axes_dict":
-            # Avoid infinite recursion for private attributes
-            return super().__getattribute__(name)
-
-        name = legacy_axis_support(name)
-
-        if (value := self.__axes_dict.get(name)) is not None:
-            return value
-
-        return super().__getattribute__(name)
+    def __getattr__(self, name: str) -> Any:
+        """Get axis value by name, with legacy W/H remapping."""
+        resolved = legacy_axis_support(name)
+        if resolved != name:
+            return super().__getattr__(resolved)
+        return super().__getattr__(name)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        """Set axis value by name using attribute syntax."""
-        if hasattr(self, "_SimulationParameters__axes_dict"):
-            # __setattr__ is called during __init__ before __axes_dict exists
-            name = legacy_axis_support(name)
-            if name in self.__axes_dict:
-                warnings.warn(f"Axis '{name}' is read-only")
-                return
+        """Block writes to axis names, delegate rest to nn.Module."""
+        if hasattr(self, "_all_axis_names") and legacy_axis_support(name) in self._all_axis_names:
+            warnings.warn(f"Axis '{name}' is read-only")
+            return
+        super().__setattr__(name, value)
 
-        return super().__setattr__(name, value)
+    def __delattr__(self, name: str) -> None:
+        """Block deletion of axis attributes."""
+        resolved = legacy_axis_support(name)
+        if hasattr(self, "_all_axis_names") and resolved in self._all_axis_names:
+            raise AttributeError(f"Cannot delete axis '{name}': axes are read-only")
+        super().__delattr__(resolved)
 
     def __contains__(self, name: str) -> bool:
         """Check if an axis exists using 'in' operator."""
-        return name in self.__axes_dict
+        return name in self._all_axis_names
 
     def __getitem__(self, name: str) -> torch.Tensor:
         """Get axis by name using bracket notation."""
-
         name = legacy_axis_support(name)
-
-        if name in self.__axes_dict:
-            return self.__axes_dict[name]
+        if name in self._all_axis_names:
+            return getattr(self, name)
         raise AxisNotFound(f"Axis '{name}' does not exist")
 
     def __setitem__(self, name: str, value: Any) -> None:
@@ -428,7 +475,7 @@ class SimulationParameters:
         x_axis = legacy_axis_support(x_axis)
         y_axis = legacy_axis_support(y_axis)
 
-        missing = [ax for ax in [x_axis, y_axis] if ax not in self.__axes_dict]
+        missing = [ax for ax in [x_axis, y_axis] if ax not in self._all_axis_names]
         if missing:
             raise AxisNotFound(f"Axes not found: {', '.join(missing)}")
 
@@ -441,17 +488,9 @@ class SimulationParameters:
         if y.dim() == 0:
             y = y.unsqueeze(0)
 
-        # TODO: if this code should be uncommented, add tests for it
-        # Only transfer to device if necessary (optimization)
-        # if x.device != self.__device:
-        #     x = x.to(self.__device)
-        # if y.device != self.__device:
-        #     y = y.to(self.__device)
-
         X, Y = torch.meshgrid(x, y, indexing="xy")
         return X, Y
 
-    @lru_cache(maxsize=CACHE_SIZE)
     def axis_sizes(self, axs: tuple[str, ...] | None = None) -> torch.Size:
         """
         Get the size of specified axes in order (cached for performance).
@@ -483,7 +522,11 @@ class SimulationParameters:
         """
 
         if axs is None:
-            axs = self.__names
+            axs = self._non_scalar_names
+
+        cached = self._cache_axis_sizes.get(axs)
+        if cached is not None:
+            return cached
 
         sizes = []
         for axis in axs:
@@ -493,7 +536,9 @@ class SimulationParameters:
 
             sizes.append(axis_len)
 
-        return torch.Size(sizes)
+        result = torch.Size(sizes)
+        self._cache_axis_sizes[axs] = result
+        return result
 
     def index(self, name: str) -> int:
         """
@@ -515,15 +560,14 @@ class SimulationParameters:
             If the axis doesn't exist or is scalar.
         """
         name = legacy_axis_support(name)
-        if name in self.__names:
-            return -self.__names_reversed.index(name) - 1
+        if name in self._non_scalar_names:
+            return -self._non_scalar_names_insertion_order.index(name) - 1
         raise AxisNotFound(f"Axis '{name}' does not exist or is scalar")
 
     ###########################################################################
     # Casting and reordering
     ###########################################################################
 
-    @lru_cache(maxsize=CACHE_SIZE)
     def _cast_info(
         self, axes: tuple[str, ...]
     ) -> tuple[tuple[str, ...], tuple[int, ...]]:
@@ -532,6 +576,10 @@ class SimulationParameters:
         tensor_axes is  tuple of (axis_name),
         tensor_sizes is tuple of (axis_size).
         """
+        cached = self._cache_cast_info.get(axes)
+        if cached is not None:
+            return cached
+
         tensor_axes: list[str] = []
         tensor_sizes: list[int] = []
 
@@ -540,18 +588,12 @@ class SimulationParameters:
             if axis_name in self._axis_names_scalar:
                 continue
 
-            # You do't need to check axis existence here because
-            # axes_size() already does that.
-            # Check axis exists
-            # if axis_name not in self.names:
-            #     raise ValueError(
-            #         f"Axis '{axis_name}' not found in simulation parameters"
-            #     )
-
             tensor_axes.append(axis_name)
             tensor_sizes.append(axis_size)
 
-        return tuple(tensor_axes), tuple(tensor_sizes)
+        result = tuple(tensor_axes), tuple(tensor_sizes)
+        self._cache_cast_info[axes] = result
+        return result
 
     def cast(
         self, tensor: torch.Tensor, *axes: str, shape_check: bool = True
@@ -597,45 +639,16 @@ class SimulationParameters:
         return cast_tensor(tensor, tensor_axes, self.axis_names)
 
     ###########################################################################
-    # Device management
+    # Device management — nn.Module.to() handles buffer transfer automatically
     ###########################################################################
-
-    def to(self, device: str | torch.device | int) -> Self:
-        """
-        Move all axes to a different device (inplace).
-
-        Unlike tensor.to() which returns a new tensor, this method
-        mutates the instance inplace (like nn.Module.to()) to ensure
-        all Elements sharing this SimulationParameters stay in sync.
-
-        Parameters
-        ----------
-        device : str | torch.device | int
-            Target device.
-
-        Returns
-        -------
-        Self
-            The same instance (for chaining).
-        """
-        target_device = torch.device(device)
-        if self.__device == target_device:
-            return self
-
-        # Mutate inplace — all references stay valid
-        for name in self.__axes_dict:
-            self.__axes_dict[name] = self.__axes_dict[name].to(target_device)
-
-        # Use actual device from tensor (e.g., 'cuda' → 'cuda:0')
-        first_tensor = next(iter(self.__axes_dict.values()))
-        self.__device = first_tensor.device
-
-        return self
 
     @property
     def device(self) -> torch.device:
         """Get the device where all axes are stored."""
-        return self.__device
+        buf = self._buffers.get("x")
+        if buf is not None:
+            return buf.device
+        return torch.get_default_device()
 
     ###########################################################################
     # Sugar
@@ -643,15 +656,15 @@ class SimulationParameters:
 
     def __dir__(self) -> list[str]:
         """List all available attributes including axes for autocompletion."""
-        attrs = list(self.__axes_dict.keys())
+        attrs = list(self._all_axis_names)
         attrs.extend(super().__dir__())
         return attrs
 
     def __repr__(self) -> str:
         """Concise string representation showing all axes."""
         axes_info = []
-        for name in sorted(self.__axes_dict.keys()):
-            tensor = self.__axes_dict[name]
+        for name in sorted(self._all_axis_names):
+            tensor = getattr(self, name)
             if tensor.dim() == 0:
                 # Scalar: show value
                 value = tensor.item()

--- a/svetlanna/simulation_parameters.py
+++ b/svetlanna/simulation_parameters.py
@@ -638,6 +638,51 @@ class SimulationParameters(nn.Module):
 
         return cast_tensor(tensor, tensor_axes, self.axis_names)
 
+    def precompute_cast(
+        self, *axes: str
+    ) -> tuple[tuple, tuple[tuple[int, int], ...]]:
+        """Precompute cast operations for ``torch.compile``-friendly forward passes.
+
+        Returns indexing tuple and swap pairs that replicate what
+        :meth:`cast` does, but without any Python-level cache lookups
+        at execution time.
+
+        Example usage in an Element::
+
+            # __init__:
+            self._cast_idx, self._cast_swaps = \\
+                self.simulation_parameters.precompute_cast("y", "x")
+
+            # forward (compile-safe):
+            t = t[self._cast_idx]
+            for i, j in self._cast_swaps:
+                t = t.swapaxes(i, j)
+
+        Parameters
+        ----------
+        *axes : str
+            Axis names corresponding to the tensor's trailing dimensions.
+
+        Returns
+        -------
+        tuple[tuple, tuple[tuple[int, int], ...]]
+            ``(indexing_tuple, swaps)`` — precomputed constants.
+        """
+        from svetlanna.axes_math import (
+            _append_slice,
+            _axes_indices_to_sort,
+            _swaps,
+            _check_new_axes,
+        )
+
+        tensor_axes, _ = self._cast_info(axes)
+        axis_names = self.axis_names
+
+        _check_new_axes(tensor_axes, axis_names)
+        indexing = _append_slice(tensor_axes, axis_names)
+        swaps = _swaps(_axes_indices_to_sort(tensor_axes, axis_names))
+        return indexing, swaps
+
     ###########################################################################
     # Device management — nn.Module.to() handles buffer transfer automatically
     ###########################################################################

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -172,6 +172,10 @@ def test_set_debug_logging(input, output, capfd, caplog):
         )
         element(*input)
 
+    expected_output_sim_params = (
+        "Module of ElementLike was registered with name simulation_parameters:\n"
+        "   <class 'svetlanna.simulation_parameters.SimulationParameters'>"
+    )
     expected_output_1 = (
         "Module of ElementLike was registered with name a:\n"
         "   <class 'torch.nn.modules.module.Module'>"
@@ -191,6 +195,7 @@ def test_set_debug_logging(input, output, capfd, caplog):
         expected_output_4 += f"\n   output {i}: {type(_output)}"
 
     expected_outputs = [
+        expected_output_sim_params,
         expected_output_1,
         expected_output_2,
         expected_output_3,

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -95,11 +95,16 @@ def test_to_device(device_simple: str):
     assert el2.a.device.type == device_simple
     assert el2.a.inner_parameter.device.type == device_simple
 
-    # test warning when elements have different devices
-    el3 = SimpleElement(
-        a=torch.tensor(123), simulation_parameters=sim_params.to(device=device_simple)
+    # test warning when elements have different simulation_parameters devices
+    sim_params_cpu = SimulationParameters(
+        {
+            "x": torch.linspace(-5 * ureg.mm, 5 * ureg.mm, 10),
+            "y": torch.linspace(-5 * ureg.mm, 5 * ureg.mm, 10),
+            "wavelength": 1,
+        }
     )
-    if el1.a.device.type != el3.a.device.type:
+    el3 = SimpleElement(a=torch.tensor(123), simulation_parameters=sim_params_cpu)
+    if el1.simulation_parameters.device != el3.simulation_parameters.device:
         with pytest.warns(UserWarning):
             LinearOpticalSetup(elements=[el1, el3])
 

--- a/tests/test_simulation_parameters.py
+++ b/tests/test_simulation_parameters.py
@@ -573,28 +573,31 @@ def test_clear_cache():
         wavelength=torch.tensor(0.5e-6),
     )
 
-    # Test axes_size cache
-    sp.axis_sizes.cache_clear()
+    # Test axis_sizes cache
+    assert len(sp._cache_axis_sizes) == 0
     sp.axis_sizes(("x", "y"))
-    assert sp.axis_sizes.cache_info().hits == 0
+    assert len(sp._cache_axis_sizes) == 1
     sp.axis_sizes(("x", "y"))
-    assert sp.axis_sizes.cache_info().hits == 1
+    assert len(sp._cache_axis_sizes) == 1  # cache hit, no new entry
 
     sp._clear_caches()
+    assert len(sp._cache_axis_sizes) == 0
     sp.axis_sizes(("x", "y"))
-    assert sp.axis_sizes.cache_info().hits == 0
+    assert len(sp._cache_axis_sizes) == 1
 
     # Test _cast_info cache
-    sp._cast_info.cache_clear()
+    sp._clear_caches()
+    assert len(sp._cache_cast_info) == 0
     t = torch.rand(100)
     sp.cast(t, "x")
-    assert sp._cast_info.cache_info().hits == 0
+    assert len(sp._cache_cast_info) == 1
     sp.cast(t, "x")
-    assert sp._cast_info.cache_info().hits == 1
+    assert len(sp._cache_cast_info) == 1  # cache hit, no new entry
 
     sp._clear_caches()
+    assert len(sp._cache_cast_info) == 0
     sp.cast(t, "x")
-    assert sp._cast_info.cache_info().hits == 0
+    assert len(sp._cache_cast_info) == 1
 
 
 def test_repr():
@@ -664,3 +667,65 @@ def test_legacy():
         )
     assert torch.allclose(sp_old.x, x)
     assert torch.allclose(sp_old.y, y)
+
+
+def test_delattr_blocked():
+    sp = SimulationParameters(
+        x=torch.linspace(-1, 1, 10),
+        y=torch.linspace(-1, 1, 10),
+        wavelength=1.0,
+    )
+    with pytest.raises(AttributeError, match="read-only"):
+        del sp.x
+    with pytest.raises(AttributeError, match="read-only"):
+        del sp.wavelength
+    # Non-axis attributes can still be deleted
+    sp._custom_attr = 42
+    del sp._custom_attr
+
+
+def test_reserved_axis_names():
+    with pytest.raises(ValueError, match="conflicts with nn.Module"):
+        SimulationParameters(
+            x=torch.linspace(-1, 1, 10),
+            y=torch.linspace(-1, 1, 10),
+            wavelength=1.0,
+            training=torch.tensor([1.0, 2.0]),
+        )
+    with pytest.raises(ValueError, match="cannot start with underscore"):
+        SimulationParameters(
+            x=torch.linspace(-1, 1, 10),
+            y=torch.linspace(-1, 1, 10),
+            wavelength=1.0,
+            _hidden=torch.tensor([1.0]),
+        )
+
+
+def test_equal_checks_axis_order():
+    sp1 = SimulationParameters(
+        x=torch.linspace(-1, 1, 10),
+        wavelength=torch.linspace(0.4, 0.6, 5),
+        y=torch.linspace(-1, 1, 8),
+    )
+    sp2 = SimulationParameters(
+        wavelength=torch.linspace(0.4, 0.6, 5),
+        x=torch.linspace(-1, 1, 10),
+        y=torch.linspace(-1, 1, 8),
+    )
+    # Same values but different axis ordering → not equal
+    assert not sp1.equal(sp2)
+
+    # Same ordering → equal
+    sp3 = sp1.clone()
+    assert sp1.equal(sp3)
+
+
+def test_clone_preserves_axis_order():
+    sp = SimulationParameters(
+        x=torch.linspace(-1, 1, 10),
+        wavelength=torch.linspace(0.4, 0.6, 5),
+        y=torch.linspace(-1, 1, 8),
+    )
+    sp2 = sp.clone()
+    assert sp.axis_names == sp2.axis_names
+    assert sp._axis_names_scalar == sp2._axis_names_scalar


### PR DESCRIPTION
## Summary

- `SimulationParameters` now inherits from `nn.Module`, with axes registered as non-persistent buffers (`persistent=False`)
- Automatic device transfer via PyTorch module tree — no more manual `.to()` override in `Element`
- Dict-based caching replaces `@lru_cache` on instance methods (avoids memory leaks per [Ruff B019](https://docs.astral.sh/ruff/rules/cached-instance-method/))
- `DiffractiveLayer.forward` is now `torch.compile`-friendly via precomputed cast ops in `__init__`

## Changes

| File | Change |
|------|--------|
| `svetlanna/simulation_parameters.py` | Inherits `nn.Module`, buffers, dict cache, guards, `precompute_cast()` |
| `svetlanna/elements/element.py` | Removed `.to()` override (redundant with submodule traversal) |
| `svetlanna/elements/diffractive_layer.py` | Precompute cast ops in `__init__` |
| `tests/test_simulation_parameters.py` | Updated cache tests, added guards/ordering tests |
| `tests/test_setup.py` | Fixed device test for correct submodule behavior |
| `tests/test_logging.py` | Added `simulation_parameters` submodule to expected debug output |

## Additional fixes

- `__delattr__` guard — prevents corrupting internal state via `del sp.x`
- Reserved name validation — blocks axis names that collide with `nn.Module` attributes (e.g. `training`)
- `equal()` now compares axis ordering, not just names and values
- Renamed `_non_scalar_names_reversed` → `_non_scalar_names_insertion_order`
- Documented that axes are excluded from `state_dict()` (non-persistent buffers)